### PR TITLE
(chore): tinyfiledialog::MessageBoxIcon is only used on Linux

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -21,7 +21,8 @@ use servo::{
     PermissionRequest, PromptDefinition, PromptOrigin, PromptResult, Servo, ServoDelegate,
     ServoError, TouchEventAction, WebView, WebViewDelegate,
 };
-use tinyfiledialogs::{self, MessageBoxIcon};
+#[cfg(target_os = "linux")]
+use tinyfiledialogs::MessageBoxIcon;
 use url::Url;
 
 use super::app::{Present, PumpResult};


### PR DESCRIPTION
This was causing a compilation warning on Mac and Windows.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

Signed-off-by: webbeef <me@webbeef.org>